### PR TITLE
Improve project card link accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,49 +250,49 @@
       <h3>eagleeye2</h3>
       <p>OSINT research platform with Kali integration. Built to be taught in courses, used by agencies, and trusted by security teams.</p>
       <div class="meta">OSINT · Security · Python</div>
-      <a class="stretched" href="https://github.com/StefanYasin/eagleeye2" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/eagleeye2" target="_blank" rel="noopener" aria-label="View the eagleeye2 project on GitHub"></a>
     </div>
     <div class="cell green flash c5 reveal">
       <div class="ic">🛡️</div>
       <h3>endpointwatch</h3>
       <p>Live-response endpoint monitoring with plain-English alerts for Windows.</p>
       <div class="meta">Monitoring · Alerts</div>
-      <a class="stretched" href="https://github.com/StefanYasin/endpointwatch" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/endpointwatch" target="_blank" rel="noopener" aria-label="View the endpointwatch project on GitHub"></a>
     </div>
     <div class="cell purple c5 reveal">
       <div class="ic">📡</div>
       <h3>pinggrid</h3>
       <p>Distributed uptime and latency tracking across a grid of nodes.</p>
       <div class="meta">Uptime · Distributed</div>
-      <a class="stretched" href="https://github.com/StefanYasin/pinggrid" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/pinggrid" target="_blank" rel="noopener" aria-label="View the pinggrid project on GitHub"></a>
     </div>
     <div class="cell flash c7 reveal">
       <div class="ic">🧊</div>
       <h3>rackpulse</h3>
       <p>Health monitoring and AI provisioning for legacy Dell PowerEdge servers on ESXi 6.7.</p>
       <div class="meta">Hardware · Telemetry</div>
-      <a class="stretched" href="https://github.com/StefanYasin/rackpulse" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/rackpulse" target="_blank" rel="noopener" aria-label="View the rackpulse project on GitHub"></a>
     </div>
     <div class="cell orange c4 reveal">
       <div class="ic">🔕</div>
       <h3>dellsilencer</h3>
       <p>Fan control with hysteresis for Dell laptops. Quiet without the screaming.</p>
       <div class="meta">Hardware · Fan Control</div>
-      <a class="stretched" href="https://github.com/StefanYasin/dellsilencer" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/dellsilencer" target="_blank" rel="noopener" aria-label="View the dellsilencer project on GitHub"></a>
     </div>
     <div class="cell flash c4 reveal">
       <div class="ic">💾</div>
       <h3>restore-drill</h3>
       <p>Backup restore verification CLI. Tests that backups actually restore, before you need them.</p>
       <div class="meta">Backups · Verification</div>
-      <a class="stretched" href="https://github.com/StefanYasin/restore-drill" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/restore-drill" target="_blank" rel="noopener" aria-label="View the restore-drill project on GitHub"></a>
     </div>
     <div class="cell green c4 reveal">
       <div class="ic">🏘️</div>
       <h3>Nextdoor Lead Engine</h3>
       <p>Scans Nextdoor for service requests, drafts replies in the right voice, tracks leads.</p>
       <div class="meta">Lead Gen · Automation</div>
-      <a class="stretched" href="https://github.com/StefanYasin/nextdoor-lead-engine" target="_blank" rel="noopener"></a>
+      <a class="stretched" href="https://github.com/StefanYasin/nextdoor-lead-engine" target="_blank" rel="noopener" aria-label="View the Nextdoor Lead Engine project on GitHub"></a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Adds accessible names to the seven project-card links so screen-reader users can identify each destination. Existing appearance and link behavior remain unchanged.